### PR TITLE
Allowing checkbox labels to contain HTML

### DIFF
--- a/ampersand-checkbox-view.js
+++ b/ampersand-checkbox-view.js
@@ -66,7 +66,7 @@ CheckboxView.prototype.render = function () {
     this.setMessage(this.message);
     this.input.checked = !!this.value;
     this.input.name = this.name;
-    this.labelEl.textContent = this.label;
+    this.labelEl.innerHTML = this.label;
     this.rendered = true;
 };
 


### PR DESCRIPTION
The interest is to be able to easily create checkboxes with embedded links, such as "I agree to the Terms of Service" (where 'Terms of Service' is a link that displays the legalese.)
The original implementation used textContent, which would convert the embedded html to html entities (\&lt;).

Per discussion w @HenrikJoreteg via Gitter, due to security considerations I'm only changing this one instance, though in theory this change could be made in many other cases.